### PR TITLE
fix-20200316:公告表单cover跟synopsis字段没加会导致添加跟编辑公告时字段为空，没有真正操作入库

### DIFF
--- a/merchant/forms/NotifyAnnounceForm.php
+++ b/merchant/forms/NotifyAnnounceForm.php
@@ -20,6 +20,8 @@ class NotifyAnnounceForm extends Notify
             [['title', 'content'], 'required'],
             [['content'], 'string'],
             [['title'], 'string', 'max' => 150],
+            [['cover'], 'string', 'max' => 100],
+            [['synopsis'], 'string', 'max' => 255],
         ];
     }
 }


### PR DESCRIPTION
#Fixes fix-20200316
公告表单cover跟synopsis字段没加会导致添加跟编辑公告时字段为空，没有真正操作入库.