### PR TITLE
订单查询时增加 merchant_id字段

### DIFF
--- a/services/order/OrderService.php
+++ b/services/order/OrderService.php
@@ -507,6 +507,7 @@ class OrderService extends \common\components\Service
             ->with(['merchant'])
             ->select([
                 'o.id',
+                'o.merchant_id',
                 'order_sn',
                 'out_trade_no',
                 'o.order_type',


### PR DESCRIPTION
查询订单的时候接口会报错，订单查询时增加 merchant_id字段