### PR TITLE
修复满额包邮运费不扣减问题

### DIFF
--- a/services/marketing/FullMailService.php
+++ b/services/marketing/FullMailService.php
@@ -58,7 +58,7 @@ class FullMailService extends Service
         if (
             $fullMail['is_open'] == StatusEnum::ENABLED &&
             $product_money >= $fullMail['full_mail_money'] &&
-            in_array($address['city_id'], StringHelper::parseAttr($fullMail['no_mail_city_ids']))
+            !in_array($address['city_id'], StringHelper::parseAttr($fullMail['no_mail_city_ids']))
         ) {
             return $fullMail;
         }


### PR DESCRIPTION
1、满额包邮设置的是不包邮地区
代码段：in_array($address['city_id'], StringHelper::parseAttr($fullMail['no_mail_city_ids'])
验证的逻辑结果是：不包邮地区才会扣减运费。因此需要取反验证
修复后：!in_array($address['city_id'], StringHelper::parseAttr($fullMail['no_mail_city_ids'])